### PR TITLE
Fixed build error when using NativeScript 6.

### DIFF
--- a/lib/after-prepare.js
+++ b/lib/after-prepare.js
@@ -3,7 +3,7 @@ const path = require('path');
 const fs = require('fs-extra');
 
 module.exports = function (hookArgs) {
-    const platform = hookArgs.platform.toLowerCase();
+    const platform = (hookArgs.platform || hookArgs.prepareData.platform).toLowerCase();
     const platformPath = path.join(hookArgs.projectData.platformsDir, platform);
     const projectPath = hookArgs.projectData.projectDir;
     const regionConfigPath = path.join(projectPath, 'region.nativescript.json');


### PR DESCRIPTION
After upgrading to NativeScript 6, structure of `hookArgs` has been changed and this causes an error when calling `toLowerCase()` on `hookArgs.platform`, which is undefined now. This fix solves this problem and makes it compatible on all versions.